### PR TITLE
fix: Use amd64 image since only amd64 binaries are provided, fixes #2

### DIFF
--- a/docker-compose.oci8.yaml
+++ b/docker-compose.oci8.yaml
@@ -1,0 +1,7 @@
+#ddev-generated
+services:
+  web:
+    # The platform statement here has no effect on AMD64/X86 systems
+    # On ARM64 (macOS Apple Silicon) it will make it work if Rosetta2 is working. The entire
+    # web container becomes amd64.
+    platform: linux/amd64

--- a/install.yaml
+++ b/install.yaml
@@ -1,7 +1,5 @@
 # Details about the install.yaml file are at https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#sections-and-features-of-ddev-get-add-on-installyaml
-
 name: oci8
-version: 1.0.0
 
 # pre_install_actions - list of actions to run before installing the addon.
 # Examples would be removing an extraneous docker volume,
@@ -60,13 +58,10 @@ pre_install_actions:
 # If you use directories, they must be directories that are managed
 # by this add-on, or removal could remove things that are not owned by it
 project_files:
+  - docker-compose.oci8.yaml
   - php/oci8.ini
   - web-build/Dockerfile.oci8
   - web-build/install-oci8.sh
-  # - some-directory/file1.txt
-  # - some-directory/file2.txt
-  # - extra_files_dir_created_by_this_template/
-  # - somefile.sh
 
 # List of files and directories that are copied into the global .ddev directory
 # DDEV environment variables can be interpolated into these filenames
@@ -96,9 +91,6 @@ post_install_actions:
 # Files listed in project_files section will be automatically removed here if they contain #ddev-generated line.
 # removal_actions are executed in the context of the target project's .ddev directory.
 removal_actions:
-  -  rm -f ${DDEV_APPROOT}/.ddev/web-build/install-oci8.sh
-  -  rm -f ${DDEV_APPROOT}/.ddev/web-build/Dockerfile.oci8
-  -  rm -f ${DDEV_APPROOT}/.ddev/php/oci8.ini
 
   # - rm ~/.ddev/commands/web/somecommand
   # - |

--- a/php/oci8.ini
+++ b/php/oci8.ini
@@ -1,2 +1,3 @@
+#ddev-generated
 [PHP]
 extension=oci8.so

--- a/web-build/Dockerfile.oci8
+++ b/web-build/Dockerfile.oci8
@@ -1,8 +1,10 @@
+#ddev-generated
+
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 # Oracle instantclient
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests gcc make autoconf libc-dev pkg-config php-pear php8.2-dev libmcrypt-dev build-essential libaio1 unzip wget
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests gcc make autoconf libc-dev pkg-config php-pear php${DDEV_PHP_VERSION}-dev libmcrypt-dev build-essential libaio1 unzip wget
 
 # Download Oracle Instant Client packages
 RUN wget https://github.com/takielias/oracle-instantclient/raw/main/instantclient-basic-linux.x64-12.1.0.2.0.zip -O /tmp/instantclient-basic-linux.x64-12.1.0.2.0.zip && \

--- a/web-build/install-oci8.sh
+++ b/web-build/install-oci8.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+#ddev-generated
+
 # Exit immediately if a command exits with a non-zero status.
 set -e
 


### PR DESCRIPTION
Issue:
* #2 


This PR adds support for running on Apple Silicon machines that have Rosetta enabled and using a Docker provider that has Rosetta enabled. I tested with Orbstack on a macbook air M4.

* Changes to `platform: linux/amd64` in new `docker-compose.oci8.yaml` so that we get a version of the web container that can work with the oracle amd64/x64 files to be installed
* Uses ${DDEV_PHP_VERSION} to specify the version to be used in the Dockerfile
* Adds #ddev-generated to the various add-on files
* Removes the explicit removal of those add-on files because it's not needed if they have #ddev-generated
* Removes `version` from the install.yaml because that's handled by release version

The build succeeds. I don't know how to test that this does what anybody needs, and this add-on does not yet have tests.

I assume this is a client-side-only Add-on, that's intended to contact an external Oracle database.

Test with 
```
ddev add-on get https://github.com/rfay/ddev-oci8/tarball/20250412_handle_arm64
```

To watch the very long and painful build:

`ddev debug rebuild`

After start,

`ddev exec arch` will show the x86_64 (amd64) architecture.
`ddev php -i` should show
```
oci8

OCI8 Support => enabled
OCI8 DTrace Support => disabled
OCI8 Version => 3.4.0
Oracle Run-time Client Library Version => 12.1.0.2.0
Oracle Compile-time Instant Client Version => 12.1

Directive => Local Value => Master Value
oci8.connection_class => no value => no value
oci8.default_prefetch => 100 => 100
oci8.events => Off => Off
oci8.max_persistent => -1 => -1
oci8.old_oci_close_semantics => Off => Off
oci8.persistent_timeout => -1 => -1
oci8.ping_interval => 60 => 60
oci8.prefetch_lob_size => 0 => 0
oci8.privileged_connect => Off => Off
oci8.statement_cache_size => 20 => 20
```

