### PR TITLE
Fix #5 build error in docker file

### DIFF
--- a/web-build/Dockerfile.oci8
+++ b/web-build/Dockerfile.oci8
@@ -13,10 +13,17 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     --no-install-recommends \
     --no-install-suggests \
     gcc make autoconf libc-dev pkg-config php-pear \
-    php${DDEV_PHP_VERSION}-dev libaio1t64 unzip wget libaio-dev
+    php${DDEV_PHP_VERSION}-dev unzip wget libaio-dev
 
 # Symlink libaio.so.1 to libaio.so.1t64 for Oracle compatibility
-RUN ln -s /lib/aarch64-linux-gnu/libaio.so.1t64 /lib/aarch64-linux-gnu/libaio.so.1 || true
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      LIB_DIR="/usr/lib/aarch64-linux-gnu"; \
+    else \
+      LIB_DIR="/usr/lib/x86_64-linux-gnu"; \
+    fi && \
+    if [ ! -e "$LIB_DIR/libaio.so.1" ]; then \
+      ln -s "$LIB_DIR/libaio.so.1t64" "$LIB_DIR/libaio.so.1" || true; \
+    fi
 
 # Download, extract and install Oracle client in one RUN block to persist variables
 RUN if [ "$TARGETARCH" = "arm64" ]; then \

--- a/web-build/Dockerfile.oci8
+++ b/web-build/Dockerfile.oci8
@@ -13,7 +13,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     --no-install-recommends \
     --no-install-suggests \
     gcc make autoconf libc-dev pkg-config php-pear \
-    php${DDEV_PHP_VERSION}-dev libaio1 unzip wget libaio-dev
+    php${DDEV_PHP_VERSION}-dev libaio1t64 unzip wget libaio-dev
+
+# Symlink libaio.so.1 to libaio.so.1t64 for Oracle compatibility
+RUN ln -s /lib/aarch64-linux-gnu/libaio.so.1t64 /lib/aarch64-linux-gnu/libaio.so.1 || true
 
 # Download, extract and install Oracle client in one RUN block to persist variables
 RUN if [ "$TARGETARCH" = "arm64" ]; then \


### PR DESCRIPTION
Also symlinks the file so the so is in the expected location and name

## The Issue
Build fails on libaio not available in version of OS on the latest image
- #5 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue
Switches to newer version of libaio 
